### PR TITLE
npm run generate Not Working During Migration to 0210 - solved

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -8,7 +8,7 @@ if(!process.env.DATABASE_URL){
 }
 
 export default {
-    dialect: "postgresql"
+    dialect: "postgresql",
     schema: '.src/lib/supabase/schema.ts',
     out: './migrations',
     driver: 'pg',

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -8,10 +8,11 @@ if(!process.env.DATABASE_URL){
 }
 
 export default {
+    dialect: "postgresql"
     schema: '.src/lib/supabase/schema.ts',
     out: './migrations',
     driver: 'pg',
     dbCredentials: {
-        connectionString: process.env.DATABASE_URL || '',
+        url: process.env.DATABASE_URL || '',
     },
 } satisfies Config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5792,9 +5792,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.3.tgz",
-      "integrity": "sha512-sntgmxj8o7DE7g/Qi60cqpLBA3HG3STcDA0kO+WfB05jEKhZMbY7umNm2rBpQvsmZ16/lPXCJGW2672dgOUkrg==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
       "dev": true,
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "push": "drizzle-kit push:pg",
-    "pull": "drizzle-kit introspect:pg ",
-    "generate": "drizzle-kit generate:pg",
+    "push": "drizzle-kit push",
+    "pull": "drizzle-kit introspect",
+    "generate": "drizzle-kit generate",
     "drop": "drizzle-kit drop",
-    "check": "drizzle-kit check:pg",
-    "up": "drizzle-kit up:pg"
+    "check": "drizzle-kit check",
+    "up": "drizzle-kit up"
   },
   "dependencies": {
     "dotenv": "^16.4.5",


### PR DESCRIPTION
Steps done to Reproduce:
1) Fork and Clone Repo: Using GitHub Desktop
2) Used `npm install` (Not related to issue but used `npm update` which updated yaml version 2.4.3 to 2.4.5
3) Run `npm run generate`
 
Actual Outcome: 
 Error:  This command is deprecated, please use updated 'generate' command (see https://orm.drizzle.team/kit-docs/upgrade-21#how-to-migrate-to-0210)
 
  
 Desired Outcome:
 Error: Cannot find the url
 
 Steps done to solve:
 1) Followed link https://orm.drizzle.team/kit-docs/upgrade-21#how-to-migrate-to-0210
 2) Removed all the `:dialect` in all scripts in package.json
 3) Added a param `dialect: "postgresql"` and changed `connectionString` param to `url` param in drizzle.config.ts
 4) Run `npm run generate`
 
Final Outcome:
Error: Cannot find the url